### PR TITLE
Fix backend tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,6 @@ name: Deploy to
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
Get `docker exec -it mpr_backend_1 python3 manage.py test` working.

Doesn't require `docker exec -it mpr_backend_1 python3 manage.py test company.tests` now.